### PR TITLE
4thGT誤字修正のアイテム名の存在判定を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_2_0_FixTypoOf4thAnniversaryGT.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_2_0_FixTypoOf4thAnniversaryGT.scala
@@ -12,7 +12,7 @@ object V1_2_0_FixTypoOf4thAnniversaryGT {
   private val gt4thName = s"$WHITE$BOLD${ITALIC}4thAniv."
 
   def is4thGiganticItem(itemStack: ItemStack): Boolean = {
-    if (itemStack == null || !itemStack.hasItemMeta || !itemStack.getItemMeta.hasLore) return false
+    if (itemStack == null || !itemStack.hasItemMeta || !itemStack.getItemMeta.hasDisplayName) return false
     val name = itemStack.getItemMeta.getDisplayName
     name.contains(gt4thName)
   }


### PR DESCRIPTION
アイテム名で判定しているのに、存在しているかの判定は説明文でやっていたのでNPEが出ていた